### PR TITLE
Remove extra opening '(' from do_stop

### DIFF
--- a/control-center-service
+++ b/control-center-service
@@ -112,7 +112,7 @@ do_stop() {
 				kill -0 "$PID"
 				[ $? -eq 0 ] && break
 				sleep 1
-				max_shutdown_wait=$((max_shutdown_wait-1)
+				max_shutdown_wait=$(max_shutdown_wait-1)
 			done
 		fi
 		exitCode=$?


### PR DESCRIPTION
This resolves https://github.com/dbtucker/cp-service/issues/1